### PR TITLE
unplayed also removes inprogress items

### DIFF
--- a/default.py
+++ b/default.py
@@ -157,6 +157,9 @@ class Main:
             self._clear_properties(request)
             count = 0
             for item in json_response['result']['movies']:
+              if item['resume']['position'] > 0 and ( (request == "RandomMovie" and self.RANDOMITEMS_UNPLAYED) or (request == 'RecentMovie' and self.RECENTITEMS_UNPLAYED) ):
+                pass
+              else:
                 count += 1
                 if item['resume']['position'] > 0:
                     resume = "true"
@@ -278,6 +281,9 @@ class Main:
             self._clear_properties(request)
             count = 0
             for item in json_response['result']['episodes']:
+              if item['resume']['position'] > 0 and ( (request == 'RandomEpisode' and self.RANDOMITEMS_UNPLAYED) or (request == 'RecentEpisode' and self.RECENTITEMS_UNPLAYED) ):
+                pass
+              else:
                 count += 1
                 '''
                 # This part is commented out because it takes 1.5second extra on my system to request these which doubles the total time.


### PR DESCRIPTION
I was expecting that the "unplayed" option removed the played and in-progress videos. This small patch  removes in-progress videos when "unplayed" option is selected.

Regards,
